### PR TITLE
Fix: Tab key issue inside shadow dom

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@rajaguruduraisamy/testcafe",
   "description": "Automated browser testing for the modern web development stack. Copied 1.8.5-alpha.2",
   "license": "MIT",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "author": {
     "name": "Developer Express Inc.",
     "url": "https://www.devexpress.com/"
@@ -53,7 +53,7 @@
   },
   "dependencies": {
     "@types/node": "^10.12.19",
-    "@rajaguruduraisamy/testcafe-hammerhead": "1.0.1",
+    "@rajaguruduraisamy/testcafe-hammerhead": "1.1.0",
     "async-exit-hook": "^1.1.2",
     "babel-core": "^6.22.1",
     "babel-plugin-transform-class-properties": "^6.24.1",

--- a/src/client/core/utils/dom.js
+++ b/src/client/core/utils/dom.js
@@ -157,10 +157,34 @@ function sortBy (property) {
     };
 }
 
+export function getAllElements (parent) {
+    let elements = [];
+
+    if (!parent)
+        return elements;
+    if (parent.shadowRoot)
+        parent = parent.shadowRoot;
+
+    const childNodes = parent.childNodes;
+    const length = getChildNodesLength(childNodes);
+
+    for (let i = 0; i < length; i++) {
+        let el = childNodes[i];
+
+        if (el.nodeType === 1)
+            elements.push(el);
+        if (el.shadowRoot)
+            el = el.shadowRoot;
+
+        elements = elements.concat(getAllElements(el));
+    }
+    return elements;
+}
+
 export function getFocusableElements (doc, sort = false) {
     // NOTE: We don't take into account the case of embedded contentEditable
     // elements and specify the contentEditable attribute for focusable elements
-    const allElements         = doc.querySelectorAll('*');
+    const allElements         = getAllElements(doc);
     const invisibleElements   = getInvisibleElements(allElements);
     const inputElementsRegExp = /^(input|button|select|textarea)$/;
     const focusableElements   = [];


### PR DESCRIPTION
Getting all elements including elements inside shadow dom for focusable elements

<!--
Thank you for your contribution.

Before making a PR, please read our contributing guidelines at
https://github.com/DevExpress/testcafe/blob/master/CONTRIBUTING.md#code-contribution

We recommend creating a *draft* PR, so that you can mark it as 'ready for review' when you are done.
-->

## Purpose
_Describe the problem you want to address or the feature you want to implement._

## Approach
_Describe how your changes address the issue or implement the desired functionality in as much detail as possible._

## References
_Provide a link to the existing issue(s), if any._

## Pre-Merge TODO
- [ ] Write tests for your proposed changes
- [ ] Make sure that existing tests do not fail
